### PR TITLE
Throw an error on cert error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## v1.5.7
+
+- Add custom error on certificate fail
 
 ## v1.5.6
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "cordova-plugin-advanced-http-custom-error",
+  "version": "1.5.7",
+  "lockfileVersion": 1,
+  "dependencies": {
+    "umd-tough-cookie": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/umd-tough-cookie/-/umd-tough-cookie-2.3.2.tgz",
+      "integrity": "sha1-g9ohGJHLpwsxfurUYIpjqZTOVu4=",
+      "dev": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "cordova-plugin-advanced-http",
-  "version": "1.5.6",
+  "name": "cordova-plugin-advanced-http-custom-error",
+  "version": "1.5.7",
   "description": "Cordova / Phonegap plugin for communicating with HTTP servers using SSL pinning",
   "scripts": {
     "build": "cp node_modules/umd-tough-cookie/lib/umd-tough-cookie.js www/umd-tough-cookie.js",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/silkimen/cordova-plugin-advanced-http.git"
+    "url": "git+https://github.com/ginjiban/cordova-plugin-advanced-http.git"
   },
   "keywords": [
     "cordova",
@@ -46,9 +46,9 @@
   ],
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/silkimen/cordova-plugin-advanced-http/issues"
+    "url": "https://github.com/ginjiban/cordova-plugin-advanced-http/issues"
   },
-  "homepage": "https://github.com/silkimen/cordova-plugin-advanced-http#readme",
+  "homepage": "https://github.com/ginjiban/cordova-plugin-advanced-http#readme",
   "devDependencies": {
     "umd-tough-cookie": "2.3.2"
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-advanced-http-custom-error",
-  "version": "1.5.7",
+  "version": "1.5.8",
   "description": "Cordova / Phonegap plugin for communicating with HTTP servers using SSL pinning",
   "scripts": {
     "build": "cp node_modules/umd-tough-cookie/lib/umd-tough-cookie.js www/umd-tough-cookie.js",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "prepublish": "npm run build"
   },
   "cordova": {
-    "id": "cordova-plugin-advanced-http",
+    "id": "cordova-plugin-advanced-http-custom-error",
     "platforms": [
       "ios",
       "android"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-advanced-http-custom-error",
-  "version": "1.5.8",
+  "version": "1.5.9",
   "description": "Cordova / Phonegap plugin for communicating with HTTP servers using SSL pinning",
   "scripts": {
     "build": "cp node_modules/umd-tough-cookie/lib/umd-tough-cookie.js www/umd-tough-cookie.js",

--- a/plugin.xml
+++ b/plugin.xml
@@ -2,7 +2,7 @@
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
   xmlns:android="http://schemas.android.com/apk/res/android"
   id="cordova-plugin-advanced-http-custom-error"
-  version="1.5.8">
+  version="1.5.9">
 
     <name>Advanced HTTP plugin</name>
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -20,6 +20,8 @@
     </js-module>
     <js-module src="www/local-storage-store.js" name="local-storage-store">
     </js-module>
+    <js-module src="www/umd-tough-cookie.js" name="umd-tough-cookie">
+    </js-module>
     <js-module src="www/cookie-handler.js" name="cookie-handler">
     </js-module>
     <js-module src="www/angular-integration.js" name="angular-integration">

--- a/plugin.xml
+++ b/plugin.xml
@@ -18,8 +18,6 @@
 
     <js-module src="www/lodash.js" name="lodash">
     </js-module>
-    <js-module src="www/umd-tough-cookie.js" name="tough-cookie">
-    </js-module>
     <js-module src="www/local-storage-store.js" name="local-storage-store">
     </js-module>
     <js-module src="www/cookie-handler.js" name="cookie-handler">

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
   xmlns:android="http://schemas.android.com/apk/res/android"
-  id="cordova-plugin-advanced-http"
+  id="cordova-plugin-advanced-http-custom-error"
   version="1.5.7">
 
     <name>Advanced HTTP plugin</name>
@@ -20,7 +20,7 @@
     </js-module>
     <js-module src="www/local-storage-store.js" name="local-storage-store">
     </js-module>
-    <js-module src="www/umd-tough-cookie.js" name="umd-tough-cookie">
+    <js-module src="www/umd-tough-cookie.js" name="tough-cookie">
     </js-module>
     <js-module src="www/cookie-handler.js" name="cookie-handler">
     </js-module>

--- a/plugin.xml
+++ b/plugin.xml
@@ -2,7 +2,7 @@
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
   xmlns:android="http://schemas.android.com/apk/res/android"
   id="cordova-plugin-advanced-http-custom-error"
-  version="1.5.7">
+  version="1.5.8">
 
     <name>Advanced HTTP plugin</name>
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -2,7 +2,7 @@
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
   xmlns:android="http://schemas.android.com/apk/res/android"
   id="cordova-plugin-advanced-http"
-  version="1.5.6">
+  version="1.5.7">
 
     <name>Advanced HTTP plugin</name>
 

--- a/src/android/com/synconset/cordovahttp/CordovaHttpPlugin.java
+++ b/src/android/com/synconset/cordovahttp/CordovaHttpPlugin.java
@@ -142,7 +142,11 @@ public class CordovaHttpPlugin extends CordovaPlugin {
             for (int i = 0; i < cerFiles.size(); i++) {
                 InputStream in = cordova.getActivity().getAssets().open(cerFiles.get(i));
                 InputStream caInput = new BufferedInputStream(in);
-                HttpRequest.addCert(caInput);
+                try {
+                    HttpRequest.addCert(caInput);
+                } catch (Exception e) {
+                    this.respondWithError(495, "Certificate invalid");
+                }
             }
             CordovaHttp.enableSSLPinning(true);
         } else {

--- a/src/android/com/synconset/cordovahttp/CordovaHttpPlugin.java
+++ b/src/android/com/synconset/cordovahttp/CordovaHttpPlugin.java
@@ -26,6 +26,7 @@ import com.github.kevinsawicki.http.HttpRequest;
 
 public class CordovaHttpPlugin extends CordovaPlugin {
     private static final String TAG = "CordovaHTTP";
+    private static CallbackContext context;
 
     @Override
     public void initialize(CordovaInterface cordova, CordovaWebView webView) {
@@ -34,6 +35,7 @@ public class CordovaHttpPlugin extends CordovaPlugin {
 
     @Override
     public boolean execute(String action, final JSONArray args, final CallbackContext callbackContext) throws JSONException {
+        context = callbackContext;
         if (action.equals("post")) {
             String urlString = args.getString(0);
             JSONObject params = args.getJSONObject(1);
@@ -111,6 +113,17 @@ public class CordovaHttpPlugin extends CordovaPlugin {
             return false;
         }
         return true;
+    }
+
+    private void respondWithError(int status, String msg) {
+        try {
+            JSONObject response = new JSONObject();
+            response.put("status", status);
+            response.put("error", msg);
+            context.error(response);
+        } catch (JSONException e) {
+            context.error(msg);
+        }
     }
 
     private void enableSSLPinning(boolean enable) throws GeneralSecurityException, IOException {

--- a/src/ios/AFNetworking/AFSecurityPolicy.m
+++ b/src/ios/AFNetworking/AFSecurityPolicy.m
@@ -224,7 +224,11 @@ static NSArray * AFPublicKeyTrustChainForServerTrust(SecTrustRef serverTrust) {
         for (NSData *certificate in self.pinnedCertificates) {
             id publicKey = AFPublicKeyForCertificate(certificate);
             if (!publicKey) {
-                continue;
+                NSException *e = [NSException
+                                  exceptionWithName:@"CertificateError"
+                                  reason:@"Error Certificate"
+                                  userInfo:nil];
+                @throw e;
             }
             [mutablePinnedPublicKeys addObject:publicKey];
         }
@@ -324,7 +328,6 @@ static NSArray * AFPublicKeyTrustChainForServerTrust(SecTrustRef serverTrust) {
 }
 
 - (instancetype)initWithCoder:(NSCoder *)decoder {
-
     self = [self init];
     if (!self) {
         return nil;

--- a/src/ios/CordovaHttpPlugin.m
+++ b/src/ios/CordovaHttpPlugin.m
@@ -11,13 +11,16 @@
 
 @end
 
-
 @implementation CordovaHttpPlugin {
     AFSecurityPolicy *securityPolicy;
 }
 
 - (void)pluginInitialize {
-    securityPolicy = [AFSecurityPolicy policyWithPinningMode:AFSSLPinningModeNone];
+    @try {
+        securityPolicy = [AFSecurityPolicy policyWithPinningMode:AFSSLPinningModeNone];
+    }
+    @catch (NSException *swag) {
+    }
 }
 
 - (void)setRequestSerializer:(NSString*)serializerName forManager:(AFHTTPSessionManager*)manager {
@@ -57,7 +60,14 @@
 - (void)enableSSLPinning:(CDVInvokedUrlCommand*)command {
     bool enable = [[command.arguments objectAtIndex:0] boolValue];
     if (enable) {
-        securityPolicy = [AFSecurityPolicy policyWithPinningMode:AFSSLPinningModeCertificate];
+        @try {
+            securityPolicy = [AFSecurityPolicy policyWithPinningMode:AFSSLPinningModeCertificate];
+        }
+        @catch (NSException *exception) {
+            CordovaHttpPlugin* __weak weakSelf = self;
+            CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:495 messageAsString:@"Invalid certificate"];
+            [weakSelf.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+        }
     } else {
         securityPolicy = [AFSecurityPolicy policyWithPinningMode:AFSSLPinningModeNone];
     }


### PR DESCRIPTION
This allows a cordova app to catch the exception and react to it.
We currently use this error to display a modal to the user with a message like "Please download the latest version"