### PR TITLE
fix gzip decompression when request header accepts gzip compression

### DIFF
--- a/src/android/com/synconset/cordovahttp/CordovaHttpDelete.java
+++ b/src/android/com/synconset/cordovahttp/CordovaHttpDelete.java
@@ -30,6 +30,7 @@ class CordovaHttpDelete extends CordovaHttp implements Runnable {
             this.setupSecurity(request);
             request.acceptCharset(CHARSET);
             request.headers(this.getHeadersMap());
+            request.uncompress(true);
 
             int code = request.code();
             String body = request.body(CHARSET);

--- a/src/android/com/synconset/cordovahttp/CordovaHttpDownload.java
+++ b/src/android/com/synconset/cordovahttp/CordovaHttpDownload.java
@@ -37,6 +37,7 @@ class CordovaHttpDownload extends CordovaHttp implements Runnable {
             this.setupSecurity(request);
             request.acceptCharset(CHARSET);
             request.headers(this.getHeadersMap());
+            request.uncompress(true);
             int code = request.code();
 
             JSONObject response = new JSONObject();

--- a/src/android/com/synconset/cordovahttp/CordovaHttpGet.java
+++ b/src/android/com/synconset/cordovahttp/CordovaHttpGet.java
@@ -30,6 +30,7 @@ class CordovaHttpGet extends CordovaHttp implements Runnable {
             this.setupSecurity(request);
             request.acceptCharset(CHARSET);
             request.headers(this.getHeadersMap());
+            request.uncompress(true);
 
             int code = request.code();
             String body = request.body(CHARSET);

--- a/src/android/com/synconset/cordovahttp/CordovaHttpHead.java
+++ b/src/android/com/synconset/cordovahttp/CordovaHttpHead.java
@@ -29,6 +29,7 @@ class CordovaHttpHead extends CordovaHttp implements Runnable {
             this.setupSecurity(request);
             request.acceptCharset(CHARSET);
             request.headers(this.getHeadersMap());
+            request.uncompress(true);
 
             int code = request.code();
             JSONObject response = new JSONObject();

--- a/src/android/com/synconset/cordovahttp/CordovaHttpPost.java
+++ b/src/android/com/synconset/cordovahttp/CordovaHttpPost.java
@@ -29,6 +29,7 @@ class CordovaHttpPost extends CordovaHttp implements Runnable {
             this.setupSecurity(request);
             request.acceptCharset(CHARSET);
             request.headers(this.getHeadersMap());
+            request.uncompress(true);
 
             if (new String("json").equals(this.getSerializerName())) {
                 request.contentType(request.CONTENT_TYPE_JSON, request.CHARSET_UTF8);

--- a/src/android/com/synconset/cordovahttp/CordovaHttpPut.java
+++ b/src/android/com/synconset/cordovahttp/CordovaHttpPut.java
@@ -29,6 +29,7 @@ class CordovaHttpPut extends CordovaHttp implements Runnable {
             this.setupSecurity(request);
             request.acceptCharset(CHARSET);
             request.headers(this.getHeadersMap());
+            request.uncompress(true);
 
             if (new String("json").equals(this.getSerializerName())) {
                 request.contentType(request.CONTENT_TYPE_JSON, request.CHARSET_UTF8);

--- a/src/android/com/synconset/cordovahttp/CordovaHttpUpload.java
+++ b/src/android/com/synconset/cordovahttp/CordovaHttpUpload.java
@@ -45,6 +45,7 @@ class CordovaHttpUpload extends CordovaHttp implements Runnable {
             this.setupSecurity(request);
             request.acceptCharset(CHARSET);
             request.headers(this.getHeadersMap());
+            request.uncompress(true);
 
             URI uri = new URI(filePath);
 


### PR DESCRIPTION
I've been mainly requesting gzipped html page in my app. This PR resolve uncompressing the response body when it's gzipped as per the comment here in `HttpRequest.java`

`public HttpRequest uncompress(final boolean uncompress);`
    

> * This will only affect requests that have the 'Content-Encoding' response
> * header set to 'gzip'.