### PR TITLE
(iOS) Add support for Content-Type application/hal+json

### DIFF
--- a/src/ios/TextResponseSerializer.m
+++ b/src/ios/TextResponseSerializer.m
@@ -23,7 +23,7 @@ static BOOL AFErrorOrUnderlyingErrorHasCodeInDomain(NSError *error, NSInteger co
         return nil;
     }
 
-    self.acceptableContentTypes = [NSSet setWithObjects:@"text/plain", @"text/html", @"text/json", @"application/json", @"text/xml", @"application/xml", @"text/css", nil];
+    self.acceptableContentTypes = [NSSet setWithObjects:@"text/plain", @"text/html", @"text/json", @"application/hal+json", @"application/json", @"text/xml", @"application/xml", @"text/css", nil];
 
     return self;
 }


### PR DESCRIPTION
Currently when the server responds with a content type of application/hal+json, the response might be 200 but AFNetwork will call the fail callback anyway because the content type is not acceptable.