### PR TITLE
Add support for Content-Type application/javascript

### DIFF
--- a/src/ios/TextResponseSerializer.m
+++ b/src/ios/TextResponseSerializer.m
@@ -23,7 +23,7 @@ static BOOL AFErrorOrUnderlyingErrorHasCodeInDomain(NSError *error, NSInteger co
         return nil;
     }
 
-    self.acceptableContentTypes = [NSSet setWithObjects:@"text/plain", @"text/html", @"text/json", @"application/hal+json", @"application/json", @"text/xml", @"application/xml", @"text/css", nil];
+    self.acceptableContentTypes = [NSSet setWithObjects:@"text/plain", @"text/html", @"text/json", @"application/hal+json", @"application/json", @"text/xml", @"application/xml", @"text/css", @"application/javascript", nil];
 
     return self;
 }


### PR DESCRIPTION
Some Javascript API Endpoints send content type 'application/javascript'. Even though the body might contain json.
Currently when a server responds with a content type of application/javascript, the response might be 200 but the AFNetwork will call the fail callback anyway because the content type is not acceptable.