### PR TITLE
Consider charset of content-type header

### DIFF
--- a/www/advanced-http.js
+++ b/www/advanced-http.js
@@ -32,7 +32,7 @@
  * An HTTP Plugin for PhoneGap.
  */
 
-var pluginId = module.id.slice(0, module.id.indexOf('.'));
+var pluginId = module.id.slice(0, module.id.lastIndexOf('.'));
 var validSerializers = ['urlencoded', 'json'];
 
 var exec = require('cordova/exec');

--- a/www/cookie-handler.js
+++ b/www/cookie-handler.js
@@ -1,4 +1,4 @@
-var pluginId = module.id.slice(0, module.id.indexOf('.'));
+var pluginId = module.id.slice(0, module.id.lastIndexOf('.'));
 var ToughCookie = require(pluginId + '.tough-cookie');
 var WebStorageCookieStore = require(pluginId + '.local-storage-store');
 

--- a/www/local-storage-store.js
+++ b/www/local-storage-store.js
@@ -30,7 +30,7 @@
 
 'use strict';
 
-var pluginId = module.id.slice(0, module.id.indexOf('.'));
+var pluginId = module.id.slice(0, module.id.lastIndexOf('.'));
 var ToughCookie = require(pluginId + '.tough-cookie');
 var _ = require(pluginId + '.lodash');
 


### PR DESCRIPTION
Use charset of content-type header to encode response data. If charset is not specified _UTF-8_ is used.