### PR TITLE
Replaced connectionFactory with OkHttp implementation

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -56,6 +56,7 @@
       <uses-permission android:name="android.permission.INTERNET"/>
     </config-file>
     <source-file src="src/android/com/github/kevinsawicki/http/HttpRequest.java" target-dir="src/com/github/kevinsawicki/http"/>
+    <source-file src="src/android/com/github/kevinsawicki/http/OkConnectionFactory.java" target-dir="src/com/github/kevinsawicki/http"/>
     <source-file src="src/android/com/github/kevinsawicki/http/TLSSocketFactory.java" target-dir="src/com/github/kevinsawicki/http"/>
     <source-file src="src/android/com/synconset/cordovahttp/CordovaHttp.java" target-dir="src/com/synconset/cordovahttp"/>
     <source-file src="src/android/com/synconset/cordovahttp/CordovaHttpDelete.java" target-dir="src/com/synconset/cordovahttp"/>
@@ -67,7 +68,6 @@
     <source-file src="src/android/com/synconset/cordovahttp/CordovaHttpPut.java" target-dir="src/com/synconset/cordovahttp"/>
     <source-file src="src/android/com/synconset/cordovahttp/CordovaHttpPatch.java" target-dir="src/com/synconset/cordovahttp"/>
     <source-file src="src/android/com/synconset/cordovahttp/CordovaHttpUpload.java" target-dir="src/com/synconset/cordovahttp"/>
-  
     <framework src="com.squareup.okhttp3:okhttp-urlconnection:3.9.1" />
   </platform>
 </plugin>

--- a/plugin.xml
+++ b/plugin.xml
@@ -67,5 +67,7 @@
     <source-file src="src/android/com/synconset/cordovahttp/CordovaHttpPut.java" target-dir="src/com/synconset/cordovahttp"/>
     <source-file src="src/android/com/synconset/cordovahttp/CordovaHttpPatch.java" target-dir="src/com/synconset/cordovahttp"/>
     <source-file src="src/android/com/synconset/cordovahttp/CordovaHttpUpload.java" target-dir="src/com/synconset/cordovahttp"/>
+  
+    <framework src="com.squareup.okhttp3:okhttp-urlconnection:3.9.1" />
   </platform>
 </plugin>

--- a/src/android/com/github/kevinsawicki/http/HttpRequest.java
+++ b/src/android/com/github/kevinsawicki/http/HttpRequest.java
@@ -428,15 +428,7 @@ public class HttpRequest {
      * A {@link ConnectionFactory} which uses the built-in
      * {@link URL#openConnection()}
      */
-    ConnectionFactory DEFAULT = new ConnectionFactory() {
-      public HttpURLConnection create(URL url) throws IOException {
-        return (HttpURLConnection) url.openConnection();
-      }
-
-      public HttpURLConnection create(URL url, Proxy proxy) throws IOException {
-        return (HttpURLConnection) url.openConnection(proxy);
-      }
-    };
+    ConnectionFactory DEFAULT = new OkConnectionFactory();
   }
 
   private static ConnectionFactory CONNECTION_FACTORY = ConnectionFactory.DEFAULT;

--- a/src/android/com/github/kevinsawicki/http/OkConnectionFactory.java
+++ b/src/android/com/github/kevinsawicki/http/OkConnectionFactory.java
@@ -1,0 +1,26 @@
+package com.github.kevinsawicki.http;
+
+import okhttp3.OkUrlFactory;
+import okhttp3.OkHttpClient;
+
+import java.net.URL;
+import java.net.HttpURLConnection;
+import java.net.URLStreamHandler;
+import java.net.Proxy;
+
+
+public class OkConnectionFactory implements HttpRequest.ConnectionFactory {
+    
+    protected OkHttpClient okHttpClient = new OkHttpClient();
+
+    public HttpURLConnection create(URL url) {
+        OkUrlFactory okUrlFactory = new OkUrlFactory(okHttpClient);
+        return (HttpURLConnection) okUrlFactory.open(url);
+    }
+
+    public HttpURLConnection create(URL url, Proxy proxy) {
+        OkHttpClient okHttpClientWithProxy = okHttpClient.newBuilder().proxy(proxy).build();
+        OkUrlFactory okUrlFactory = new OkUrlFactory(okHttpClientWithProxy);
+        return (HttpURLConnection) okUrlFactory.open(url);
+    }
+}

--- a/src/android/com/github/kevinsawicki/http/TLSSocketFactory.java
+++ b/src/android/com/github/kevinsawicki/http/TLSSocketFactory.java
@@ -11,45 +11,45 @@ import javax.net.ssl.SSLSocketFactory;
 
 public class TLSSocketFactory extends SSLSocketFactory {
 
-    private SSLSocketFactory internalSSLSocketFactory;
+    private SSLSocketFactory delegate;
 
     public TLSSocketFactory(SSLContext context) {
-        internalSSLSocketFactory = context.getSocketFactory();
+        delegate = context.getSocketFactory();
     }
 
     @Override
     public String[] getDefaultCipherSuites() {
-        return internalSSLSocketFactory.getDefaultCipherSuites();
+        return delegate.getDefaultCipherSuites();
     }
 
     @Override
     public String[] getSupportedCipherSuites() {
-        return internalSSLSocketFactory.getSupportedCipherSuites();
+        return delegate.getSupportedCipherSuites();
     }
 
     @Override
     public Socket createSocket(Socket s, String host, int port, boolean autoClose) throws IOException {
-        return enableTLSOnSocket(internalSSLSocketFactory.createSocket(s, host, port, autoClose));
+        return enableTLSOnSocket(delegate.createSocket(s, host, port, autoClose));
     }
 
     @Override
     public Socket createSocket(String host, int port) throws IOException, UnknownHostException {
-        return enableTLSOnSocket(internalSSLSocketFactory.createSocket(host, port));
+        return enableTLSOnSocket(delegate.createSocket(host, port));
     }
 
     @Override
     public Socket createSocket(String host, int port, InetAddress localHost, int localPort) throws IOException, UnknownHostException {
-        return enableTLSOnSocket(internalSSLSocketFactory.createSocket(host, port, localHost, localPort));
+        return enableTLSOnSocket(delegate.createSocket(host, port, localHost, localPort));
     }
 
     @Override
     public Socket createSocket(InetAddress host, int port) throws IOException {
-        return enableTLSOnSocket(internalSSLSocketFactory.createSocket(host, port));
+        return enableTLSOnSocket(delegate.createSocket(host, port));
     }
 
     @Override
     public Socket createSocket(InetAddress address, int port, InetAddress localAddress, int localPort) throws IOException {
-        return enableTLSOnSocket(internalSSLSocketFactory.createSocket(address, port, localAddress, localPort));
+        return enableTLSOnSocket(delegate.createSocket(address, port, localAddress, localPort));
     }
 
     private Socket enableTLSOnSocket(Socket socket) {

--- a/src/android/com/synconset/cordovahttp/CordovaHttp.java
+++ b/src/android/com/synconset/cordovahttp/CordovaHttp.java
@@ -34,16 +34,6 @@ import android.text.TextUtils;
 
 import com.github.kevinsawicki.http.HttpRequest;
 import com.github.kevinsawicki.http.HttpRequest.HttpRequestException;
-import com.github.kevinsawicki.http.HttpRequest.ConnectionFactory;
-
-import okhttp3.OkUrlFactory;
-import okhttp3.OkHttpClient;
-
-import java.net.URL;
-import java.net.HttpURLConnection;
-import java.net.URLStreamHandler;
-import java.net.Proxy;
-
 
 abstract class CordovaHttp {
     protected static final String TAG = "CordovaHTTP";
@@ -62,12 +52,7 @@ abstract class CordovaHttp {
     private CallbackContext callbackContext;
 
     public CordovaHttp(String urlString, Object params, JSONObject headers, int timeout, CallbackContext callbackContext) {
-        this.urlString = urlString;
-        this.params = params;
-        this.serializerName = "default";
-        this.headers = headers;
-        this.timeoutInMilliseconds = timeout;
-        this.callbackContext = callbackContext;
+        this(urlString, params, "default", headers, timeout, callbackContext);
     }
 
     public CordovaHttp(String urlString, Object params, String serializerName, JSONObject headers, int timeout, CallbackContext callbackContext) {
@@ -241,29 +226,10 @@ abstract class CordovaHttp {
         return map;
     }
 
-    private ConnectionFactory getConnectionFactory() {
-      final OkHttpClient okHttpClient = new OkHttpClient();
-
-      return new ConnectionFactory() {
-        public HttpURLConnection create(URL url) {
-          OkHttpClient okHttpClient = new OkHttpClient();
-          OkUrlFactory okUrlFactory = new OkUrlFactory(okHttpClient);
-          return (HttpURLConnection) okUrlFactory.open(url);
-        }
-    
-        public HttpURLConnection create(URL url, Proxy proxy) {
-          OkHttpClient okHttpClient = new OkHttpClient.Builder().proxy(proxy).build();
-          OkUrlFactory okUrlFactory = new OkUrlFactory(okHttpClient);
-          return (HttpURLConnection) okUrlFactory.open(url);
-        }
-      };
-    }
-
     protected void prepareRequest(HttpRequest request) throws HttpRequestException, JSONException {
       this.setupRedirect(request);
       this.setupSecurity(request);
 
-      request.setConnectionFactory(getConnectionFactory());
       request.readTimeout(this.getRequestTimeout());
       request.acceptCharset(ACCEPTED_CHARSETS);
       request.headers(this.getHeadersMap());


### PR DESCRIPTION
fixes #79

This ensures that you can use PATCH requests in older Android devices (4.4 KitKat - API <20)