### PR TITLE
Add general-purpose interceptor hooks to cordova-plugin-approov-http …

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<plugin xmlns="http://www.phonegap.com/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android" id="cordova-plugin-advanced-http" version="1.11.1">
+<plugin xmlns="http://www.phonegap.com/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android" id="cordova-plugin-advanced-http" version="2.0.0">
   <name>Advanced HTTP plugin</name>
   <description>
         Cordova / Phonegap plugin for communicating with HTTP servers using SSL pinning

--- a/src/android/com/synconset/cordovahttp/CordovaHttpPlugin.java
+++ b/src/android/com/synconset/cordovahttp/CordovaHttpPlugin.java
@@ -134,6 +134,14 @@ public class CordovaHttpPlugin extends CordovaPlugin {
         return true;
     }
 
+    // Public interface type for request interceptors
+    public interface IHttpRequestInterceptor extends CordovaHttp.IHttpRequestInterceptor {};
+
+    // Add a request interceptor to the list of request interceptors
+    public static final void addRequestInterceptor(IHttpRequestInterceptor requestInteceptor) {
+        CordovaHttp.addRequestInterceptor(requestInteceptor);
+    };
+
     private void loadSSLCerts() throws GeneralSecurityException, IOException {
         AssetManager assetManager = cordova.getActivity().getAssets();
         String[] files = assetManager.list("");


### PR DESCRIPTION
…so additional functionality can be called if required.

The hooks allow, for example, to implement certificate pinning where the trusted certificate can be changed dynamically at run-time.
As long as these hooks are not used, the plugin's functionality and behaviour are not affected.

Our aim is for these hooks to be general and useful enough that they will be accepted as contributions by you, the maintainer of cordova-plugin-approov-http.

To see what we at CriticalBlue (https://www.approov.io/) have been able to do using these hooks please see https://www.approov.io/blog/using-approov-in-your-cordova-app-the-easy-way.html
In a nutshell: we were able to integrate our mobile API protection with cordova-plugin-advanced-http without changing the way the latter is being used. Other people and organizations could use the same method to integrate their specialized functionality.

To see how we implemented the integration please refer to https://www.approov.io/blog/how-we-integrated-approov-with-cordova.html
in particular sections "Integration Approach" and "Cordova Advanced HTTP - Adding Interceptor Hooks"