### PR TITLE
add support for setting proxy

### DIFF
--- a/src/android/com/synconset/cordovahttp/CordovaHttpPlugin.java
+++ b/src/android/com/synconset/cordovahttp/CordovaHttpPlugin.java
@@ -128,6 +128,12 @@ public class CordovaHttpPlugin extends CordovaPlugin {
             boolean disable = args.getBoolean(0);
             CordovaHttp.disableRedirect(disable);
             callbackContext.success();
+        } else if (action.equals("setProxy")) {
+            String host = args.getString(0);
+            int port = args.getInt(1);
+            HttpRequest.proxyHost(host);
+            HttpRequest.proxyPort(port);
+            callbackContext.success();
         } else {
             return false;
         }

--- a/www/advanced-http.js
+++ b/www/advanced-http.js
@@ -72,6 +72,9 @@ var publicInterface = {
   disableRedirect: function (disable, success, failure) {
     return exec(success, failure, 'CordovaHttpPlugin', 'disableRedirect', [ !!disable ]);
   },
+  setProxy: function(host, port, success, failure) {
+    return exec(success, failure, 'CordovaHttpPlugin', 'setProxy', [ host, port ]);
+  },
   sendRequest: function (url, options, success, failure) {
     helpers.handleMissingCallbacks(success, failure);
 


### PR DESCRIPTION
This PR adds the ability to set a proxy host and port. Setting a proxy was already available on HttpRequest, so I only added a method to expose it on the plugin interface.

Cheers 🍻 