### PR TITLE
Fix argument double encoding on file download

### DIFF
--- a/src/android/com/synconset/cordovahttp/CordovaHttpDownload.java
+++ b/src/android/com/synconset/cordovahttp/CordovaHttpDownload.java
@@ -31,7 +31,7 @@ class CordovaHttpDownload extends CordovaHttp implements Runnable {
     @Override
     public void run() {
         try {
-            HttpRequest request = HttpRequest.get(this.getUrlString(), this.getParamsMap(), true);
+            HttpRequest request = HttpRequest.get(this.getUrlString(), this.getParamsMap(), false);
 
             this.prepareRequest(request);
 


### PR DESCRIPTION
By trying to pass a mime type as an argument in `downloadFile` on Android I noticed that the url is double encoded.
Passing `image/jpeg` gives `image%252Fjpeg` instead of `image%2Fjpeg`.

As done in `CordovaHttpGet`, I disabled parameters encoding in `HttpRequest` constructor.

No idea if the issue exists on iOS.