### PR TITLE
Fix argument double encoding for HttpHead

### DIFF
--- a/src/android/com/synconset/cordovahttp/CordovaHttpHead.java
+++ b/src/android/com/synconset/cordovahttp/CordovaHttpHead.java
@@ -23,7 +23,7 @@ class CordovaHttpHead extends CordovaHttp implements Runnable {
     @Override
     public void run() {
         try {
-            HttpRequest request = HttpRequest.head(this.getUrlString(), this.getParamsMap(), true);
+            HttpRequest request = HttpRequest.head(this.getUrlString(), this.getParamsMap(), false);
 
             this.prepareRequest(request);
             this.returnResponseObject(request);


### PR DESCRIPTION
To follow #157 that fixed double encoding on file download