### PR TITLE
 Keep AFHTTPSessionManager instance with the plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.0.2
+
+- Fixed #142: Plugin affected by REDoS Issue of tough-cookie
+
 ## 2.0.1
 
 - Fixed #136: Content-Type header non-overwritable on browser platform

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-advanced-http",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Cordova / Phonegap plugin for communicating with HTTP servers using SSL pinning",
   "scripts": {
     "updatecert": "node ./scripts/update-test-cert.js",
@@ -63,7 +63,7 @@
     "mocha": "4.0.0",
     "mock-require": "2.0.2",
     "mz": "2.7.0",
-    "umd-tough-cookie": "2.3.2",
+    "umd-tough-cookie": "2.4.3",
     "wd": "1.4.1",
     "xml2js": "0.4.19"
   }


### PR DESCRIPTION
Persist the AFHTTPSessionManager instance for the life of the plugin to allow reusing the underlying sockets, for example, with "Connection: keep-alive" headers. Hopefully, this addresses the issue https://github.com/silkimen/cordova-plugin-advanced-http/issues/115 .