### PR TITLE
Fix WebStorageCookieStore getAllCookies()

### DIFF
--- a/www/local-storage-store.js
+++ b/www/local-storage-store.js
@@ -146,7 +146,7 @@ module.exports = function init(ToughCookie, _) {
 
     Object.keys(store).forEach(function (domain) {
       Object.keys(store[domain]).forEach(function (path) {
-        Array.protype.push.apply(cookies, _.values(store[domain][path]));
+        Array.prototype.push.apply(cookies, _.values(store[domain][path]));
       });
     });
 


### PR DESCRIPTION
Failing getAllCookies() because of a typo in Array.prototype call

`TypeError: Cannot read property 'push' of undefined`