### PR TITLE
options.data is being set to null where previously it was undefined

### DIFF
--- a/www/helpers.js
+++ b/www/helpers.js
@@ -474,7 +474,7 @@ module.exports = function init(global, jsUtil, cookieHandler, messages, base64, 
     options = options || {};
 
     return {
-      data: options.data,
+      data: jsUtil.getTypeOf(options.data) === 'Undefined' ? {} : options.data,
       filePath: options.filePath,
       followRedirect: checkFollowRedirectValue(options.followRedirect || globals.followRedirect),
       headers: checkHeadersObject(options.headers || {}),

--- a/www/helpers.js
+++ b/www/helpers.js
@@ -474,7 +474,7 @@ module.exports = function init(global, jsUtil, cookieHandler, messages, base64, 
     options = options || {};
 
     return {
-      data: jsUtil.getTypeOf(options.data) === 'Undefined' ? null : options.data,
+      data: options.data,
       filePath: options.filePath,
       followRedirect: checkFollowRedirectValue(options.followRedirect || globals.followRedirect),
       headers: checkHeadersObject(options.headers || {}),


### PR DESCRIPTION
By setting options.data to null, then checking it's validity in processData, it is being considered invalid causing the request to fail:
```javascript
switch (options.method) {
      case 'post':
      case 'put':
      case 'patch':
        return helpers.processData(options.data, options.serializer, function(data) {
          exec(onSuccess, onFail, 'CordovaHttpPlugin', options.method, [url, data, options.serializer, headers, options.timeout, options.followRedirect, options.responseType]);
        });
...
```

If the options.data property is undefined, it has not been provided, therefore it should not be set to null - please correct this.