### PR TITLE
Array buffer requests

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -31,6 +31,7 @@
       </feature>
     </config-file>
     <header-file src="src/ios/CordovaHttpPlugin.h"/>
+    <header-file src="src/ios/BinaryRequestSerializer.h"/>
     <header-file src="src/ios/BinaryResponseSerializer.h"/>
     <header-file src="src/ios/TextResponseSerializer.h"/>
     <header-file src="src/ios/TextRequestSerializer.h"/>
@@ -43,6 +44,7 @@
     <header-file src="src/ios/AFNetworking/AFURLSessionManager.h"/>
     <header-file src="src/ios/SDNetworkActivityIndicator/SDNetworkActivityIndicator.h"/>
     <source-file src="src/ios/CordovaHttpPlugin.m"/>
+    <source-file src="src/ios/BinaryRequestSerializer.m"/>
     <source-file src="src/ios/BinaryResponseSerializer.m"/>
     <source-file src="src/ios/TextResponseSerializer.m"/>
     <source-file src="src/ios/TextRequestSerializer.m"/>

--- a/src/android/com/silkimen/cordovahttp/CordovaHttpBase.java
+++ b/src/android/com/silkimen/cordovahttp/CordovaHttpBase.java
@@ -147,6 +147,8 @@ abstract class CordovaHttpBase implements Runnable {
       // intentionally left blank, because content type is set in HttpRequest.form()
     } else if ("multipart".equals(this.serializer)) {
       request.contentType("multipart/form-data");
+    } else if ("arraybuffer".equals(this.serializer)) {
+      // intentionally left blank, because content type should be explicitly set by user
     }
   }
 
@@ -177,6 +179,9 @@ abstract class CordovaHttpBase implements Runnable {
           request.part(name, fileNames.getString(i), types.getString(i), new ByteArrayInputStream(bytes));
         }
       }
+    } else if ("arraybuffer".equals(this.serializer)) {
+      // this.data is a Base64-encoded java.lang.String
+      request.send(Base64.decode((String)this.data, Base64.DEFAULT));
     }
   }
 

--- a/src/ios/BinaryRequestSerializer.h
+++ b/src/ios/BinaryRequestSerializer.h
@@ -1,0 +1,8 @@
+#import <Foundation/Foundation.h>
+#import "AFURLRequestSerialization.h"
+
+@interface BinaryRequestSerializer : AFHTTPRequestSerializer
+
++ (instancetype)serializer;
+
+@end

--- a/src/ios/BinaryRequestSerializer.m
+++ b/src/ios/BinaryRequestSerializer.m
@@ -1,0 +1,49 @@
+#import "BinaryRequestSerializer.h"
+
+@implementation BinaryRequestSerializer
+
++ (instancetype)serializer
+{
+    BinaryRequestSerializer *serializer = [[self alloc] init];
+    return serializer;
+}
+
+#pragma mark - AFURLRequestSerialization
+
+- (NSURLRequest *)requestBySerializingRequest:(NSURLRequest *)request
+                               withParameters:(id)parameters
+                                        error:(NSError *__autoreleasing *)error
+{
+    NSParameterAssert(request);
+
+    if ([self.HTTPMethodsEncodingParametersInURI containsObject:[[request HTTPMethod] uppercaseString]]) {
+        return [super requestBySerializingRequest:request withParameters:parameters error:error];
+    }
+
+    NSMutableURLRequest *mutableRequest = [request mutableCopy];
+
+    [self.HTTPRequestHeaders enumerateKeysAndObjectsUsingBlock:^(id field, id value, BOOL * __unused stop) {
+        if (![request valueForHTTPHeaderField:field]) {
+            [mutableRequest setValue:value forHTTPHeaderField:field];
+        }
+    }];
+
+    if (parameters) {
+        [mutableRequest setHTTPBody: parameters];
+    }
+
+    return mutableRequest;
+}
+
+#pragma mark - NSSecureCoding
+
+- (instancetype)initWithCoder:(NSCoder *)decoder {
+    self = [super initWithCoder:decoder];
+    if (!self) {
+        return nil;
+    }
+
+    return self;
+}
+
+@end

--- a/src/ios/CordovaHttpPlugin.m
+++ b/src/ios/CordovaHttpPlugin.m
@@ -1,5 +1,6 @@
 #import "CordovaHttpPlugin.h"
 #import "CDVFile.h"
+#import "BinaryRequestSerializer.h"
 #import "BinaryResponseSerializer.h"
 #import "TextResponseSerializer.h"
 #import "TextRequestSerializer.h"
@@ -31,6 +32,8 @@
         manager.requestSerializer = [AFJSONRequestSerializer serializer];
     } else if ([serializerName isEqualToString:@"utf8"]) {
         manager.requestSerializer = [TextRequestSerializer serializer];
+    } else if ([serializerName isEqualToString:@"arraybuffer"]) {
+        manager.requestSerializer = [BinaryRequestSerializer serializer];
     } else {
         manager.requestSerializer = [AFHTTPRequestSerializer serializer];
     }

--- a/www/helpers.js
+++ b/www/helpers.js
@@ -394,7 +394,7 @@ module.exports = function init(global, jsUtil, cookieHandler, messages, base64, 
     }
 
     if (!allowedInstanceTypes && allowedDataTypes.indexOf(currentDataType) === -1) {
-      throw new Error(messages.TYPE_MISMATCH_DATA + ' ' + allowedDataTypes.join(', '));
+      throw new Error(messages.TYPE_MISMATCH_DATA + ' ' + allowedDataTypes.join(', ') + messages.TYPE_MISMATCH_DATA_PROVIDED + ' ' + currentDataType);
     }
 
     switch (dataSerializer) {

--- a/www/helpers.js
+++ b/www/helpers.js
@@ -1,5 +1,5 @@
 module.exports = function init(global, jsUtil, cookieHandler, messages, base64, errorCodes, dependencyValidator, ponyfills) {
-  var validSerializers = ['urlencoded', 'json', 'utf8', 'multipart'];
+  var validSerializers = ['urlencoded', 'json', 'utf8', 'multipart', 'arraybuffer'];
   var validCertModes = ['default', 'nocheck', 'pinned', 'legacy'];
   var validClientAuthModes = ['none', 'systemstore', 'buffer'];
   var validHttpMethods = ['get', 'put', 'post', 'patch', 'head', 'delete', 'upload', 'download'];
@@ -365,6 +365,8 @@ module.exports = function init(global, jsUtil, cookieHandler, messages, base64, 
         return ['Object'];
       case 'json':
         return ['Array', 'Object'];
+      case 'arraybuffer':
+        return ['ArrayBuffer'];
       default:
         return [];
     }

--- a/www/messages.js
+++ b/www/messages.js
@@ -25,6 +25,7 @@ module.exports = {
   MISSING_TEXT_ENCODER_API: 'advanced-http: TextEncoder API is not supported in this webview. If you want to use "multipart/form-data" requests, you need to load a polyfill library before loading this plugin. Check out https://github.com/silkimen/cordova-plugin-advanced-http/wiki/Web-APIs-required-for-Multipart-requests for more info.',
   POST_PROCESSING_FAILED: 'advanced-http: an error occured during post processing response:',
   TYPE_MISMATCH_DATA: 'advanced-http: "data" option is configured to support only following data types:',
+  TYPE_MISMATCH_DATA_PROVIDED: '. You provided the data type:',
   TYPE_MISMATCH_FILE_PATHS: 'advanced-http: "filePaths" option needs to be an string array, <filePaths: string[]>',
   TYPE_MISMATCH_HEADERS: 'advanced-http: "headers" option needs to be an dictionary style object with string values, <headers: {[key: string]: string}>',
   TYPE_MISMATCH_NAMES: 'advanced-http: "names" option needs to be an string array, <names: string[]>',


### PR DESCRIPTION
This PR adds the possibility to "upload" (tested with PUT here) binary/arbitrary data using cordova-plugin-advanced-http. This is achieved by introducing a new data serializer called "arraybuffer" which, as you might have expected, expects an ArrayBuffer-object on the JavaScript side.
For Android, the data is automatically converted to a Base64-encoded string by cordova. The Java-part of the plugin decodes the string and sends the request.
For iOS, a new "BinaryRequestSerializer" class was introduced. I copied the "TextRequestSerializer" and had to modify only some lines from there.

Since I fell on it when I started, the plugin will now also report which data type was provided but not supported by the serializer.