### PR TITLE
Response type "json" not working correctly

### DIFF
--- a/src/android/com/silkimen/cordovahttp/CordovaHttpBase.java
+++ b/src/android/com/silkimen/cordovahttp/CordovaHttpBase.java
@@ -193,7 +193,7 @@ abstract class CordovaHttpBase implements Runnable {
     response.setHeaders(request.headers());
 
     if (request.code() >= 200 && request.code() < 300) {
-      if ("text".equals(this.responseType)) {
+      if ("text".equals(this.responseType) || "json".equals(this.responseType)) {
         String decoded = HttpBodyDecoder.decodeBody(outputStream.toByteArray(), request.charset());
         response.setBody(decoded);
       } else {

--- a/src/ios/CordovaHttpPlugin.m
+++ b/src/ios/CordovaHttpPlugin.m
@@ -62,7 +62,7 @@
 }
 
 - (void)setResponseSerializer:(NSString*)responseType forManager:(AFHTTPSessionManager*)manager {
-    if ([responseType isEqualToString: @"text"]) {
+    if ([responseType isEqualToString: @"text"] || [responseType isEqualToString: @"json"]) {
         manager.responseSerializer = [TextResponseSerializer serializer];
     } else {
         manager.responseSerializer = [BinaryResponseSerializer serializer];


### PR DESCRIPTION
When using the cordova plugin I experienced the same bug as mentioned in #286. For me the bug occurs when using responseType **json** on the platforms **ios** and **android**.

While debugging the code I found out, that the error is thrown here: 
```javascript
// json
if (responseType === validResponseTypes[1]) {
  response.data = JSON.parse(response.data);
}
```
[_www/helpers.js_](https://github.com/silkimen/cordova-plugin-advanced-http/blob/master/www/helpers.js#L296)

Then I noticed, that with responseType set to json `response.data` is always a base64 encoded string of the json data. For me that doesn't make sense (as json is a form of text). I edited the native android and ios code to use the text serialization on responseType json.

**I have not checked platform browser.**