### PR TITLE
apply timeout correctly on android

### DIFF
--- a/src/android/com/silkimen/cordovahttp/CordovaHttpBase.java
+++ b/src/android/com/silkimen/cordovahttp/CordovaHttpBase.java
@@ -122,6 +122,7 @@ abstract class CordovaHttpBase implements Runnable {
   protected void prepareRequest(HttpRequest request) throws JSONException, IOException {
     request.followRedirects(this.followRedirects);
     request.readTimeout(this.timeout);
+    request.connectTimeout(this.timeout);
     request.acceptCharset("UTF-8");
     request.uncompress(true);
     HttpRequest.setConnectionFactory(new OkConnectionFactory());


### PR DESCRIPTION
Also set connectTimeout. Without this, the default timeout of 0 is in effect which causes request to fail after a long time