### PR TITLE
Multipart: add Content-Type for text/plain and application/json

### DIFF
--- a/src/android/com/silkimen/cordovahttp/CordovaHttpBase.java
+++ b/src/android/com/silkimen/cordovahttp/CordovaHttpBase.java
@@ -176,7 +176,7 @@ abstract class CordovaHttpBase implements Runnable {
         String name = names.getString(i);
 
         if (fileNames.isNull(i)) {
-          request.part(name, new String(bytes, "UTF-8"));
+          request.part(name, null, types.getString(i), new String(bytes, "UTF-8"));
         } else {
           request.part(name, fileNames.getString(i), types.getString(i), new ByteArrayInputStream(bytes));
         }

--- a/src/ios/CordovaHttpPlugin.m
+++ b/src/ios/CordovaHttpPlugin.m
@@ -264,7 +264,10 @@
                 if (![fileName isEqual:[NSNull null]]) {
                     [formData appendPartWithFileData:decodedBuffer name:partName fileName:fileName mimeType:partType];
                 } else {
-                    [formData appendPartWithFormData:decodedBuffer name:[names objectAtIndex:i]];
+                    NSMutableDictionary *mutableHeaders = [NSMutableDictionary dictionary];
+                    [mutableHeaders setValue:[NSString stringWithFormat:@"form-data; name=\"%@\"", partName] forKey:@"Content-Disposition"];
+                    [mutableHeaders setValue:partType forKey:@"Content-Type"];
+                    [formData appendPartWithHeaders:mutableHeaders body:decodedBuffer];
                 }
             }
             

--- a/www/helpers.js
+++ b/www/helpers.js
@@ -455,7 +455,12 @@ module.exports = function init(global, jsUtil, cookieHandler, messages, base64, 
       result.buffers.push(base64.fromArrayBuffer(textEncoder.encode(entry.value[1]).buffer));
       result.names.push(entry.value[0]);
       result.fileNames.push(null);
-      result.types.push('text/plain');
+      try {
+        JSON.parse(entry.value[1]);
+        result.types.push('application/json');
+      } catch (error) {
+        result.types.push('text/plain');
+      }
 
       return processFormDataIterator(iterator, textEncoder, result, onFinished)
     }


### PR DESCRIPTION
For multipart requests there was no Content-Type for text/plain and application/json.

I added this because some api's like [salesforce](https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/dome_sobject_insert_update_blob.htm) need the Content-Type to work properly.

If you need more information just ask.