### PR TITLE
fix(): default filename for blob

### DIFF
--- a/test/js-specs.js
+++ b/test/js-specs.js
@@ -629,6 +629,44 @@ describe('Common helpers', function () {
       });
     });
 
+    it('processes data correctly when serializer "multipart" is configured and form data contains file value (filename set)', (cb) => {
+      const formData = new FormDataMock();
+      formData.append('myFile', new BlobMock([testString], { type: 'application/octet-stream' }), 'file.name');
+
+      helpers.processData(formData, 'multipart', (data) => {
+        data.buffers.length.should.be.equal(1);
+        data.names.length.should.be.equal(1);
+        data.fileNames.length.should.be.equal(1);
+        data.types.length.should.be.equal(1);
+
+        data.buffers[0].should.be.eql(testStringBase64);
+        data.names[0].should.be.equal('myFile');
+        data.fileNames[0].should.be.equal('file.name');
+        data.types[0].should.be.equal('application/octet-stream');
+
+        cb();
+      });
+    });
+
+    it('processes data correctly when serializer "multipart" is configured and form data contains file value (filename empty)', (cb) => {
+      const formData = new FormDataMock();
+      formData.append('myFile', new BlobMock([testString], { type: 'application/octet-stream' }), '');
+
+      helpers.processData(formData, 'multipart', (data) => {
+        data.buffers.length.should.be.equal(1);
+        data.names.length.should.be.equal(1);
+        data.fileNames.length.should.be.equal(1);
+        data.types.length.should.be.equal(1);
+
+        data.buffers[0].should.be.eql(testStringBase64);
+        data.names[0].should.be.equal('myFile');
+        data.fileNames[0].should.be.equal('');
+        data.types[0].should.be.equal('application/octet-stream');
+
+        cb();
+      });
+    });
+
     it('processes data correctly when serializer "raw" is configured', (cb) => {
       const byteArray = new Uint8Array([1, 2, 3]);
       helpers.processData(byteArray, 'raw', (data) => {

--- a/test/mocks/File.mock.js
+++ b/test/mocks/File.mock.js
@@ -3,7 +3,7 @@ const BlobMock = require('./Blob.mock');
 module.exports = class FileMock extends BlobMock {
   constructor(blob, fileName) {
     super(blob, { type: blob.type });
-    this._fileName = fileName || '';
+    this._fileName = fileName !== undefined ? fileName : 'blob';
     this.__lastModifiedDate = new Date();
   }
 

--- a/www/helpers.js
+++ b/www/helpers.js
@@ -453,7 +453,7 @@ module.exports = function init(global, jsUtil, cookieHandler, messages, base64, 
       reader.onload = function () {
         result.buffers.push(base64.fromArrayBuffer(reader.result));
         result.names.push(entry.value[0]);
-        result.fileNames.push(entry.value[1].name || 'blob');
+        result.fileNames.push(entry.value[1].name !== undefined ? entry.value[1].name : 'blob');
         result.types.push(entry.value[1].type || '');
         processFormDataIterator(iterator, textEncoder, result, onFinished);
       };

--- a/www/ponyfills.js
+++ b/www/ponyfills.js
@@ -16,7 +16,7 @@ module.exports = function init(global) {
     } else if (global.Blob && value instanceof global.Blob) {
       // mimic File instance by adding missing properties
       value.lastModifiedDate = new Date();
-      value.name = filename || '';
+      value.name = fileName !== undefined ? fileName : 'blob';
     } else {
       value = String(value);
     }

--- a/www/ponyfills.js
+++ b/www/ponyfills.js
@@ -16,7 +16,7 @@ module.exports = function init(global) {
     } else if (global.Blob && value instanceof global.Blob) {
       // mimic File instance by adding missing properties
       value.lastModifiedDate = new Date();
-      value.name = fileName !== undefined ? fileName : 'blob';
+      value.name = filename !== undefined ? filename : 'blob';
     } else {
       value = String(value);
     }


### PR DESCRIPTION
## Background
> [Mozilla FormData.append](https://developer.mozilla.org/en-US/docs/Web/API/FormData/append) filename (optional):
> The filename reported to the server (a USVString), when a Blob or File is passed as the second parameter. The default filename for Blob objects is "blob". The default filename for File objects is the file's filename.

## How the browser works
Basically the filename `blob` is set by `formData.append` if blob with no filename is passed.
(I tested this on Safari, Chrome, Firefox, iOS and Android)
```js
// no filename passed
formData = new FormData();

formData.append('json', new Blob(['{"bla":1}'], {type: 'application/json'}));

console.log(formData.entries().next().value[1].name); // will print 'blob'

// empty filename passed
formData = new FormData();

formData.append('json', new Blob(['{"bla":1}'], {type: 'application/json'}), '');

console.log(formData.entries().next().value[1].name); // will print ''
```

## What the plugin does wrong
In the plugin `www\helpers.js:456`:
```js
result.fileNames.push(entry.value[1].name || 'blob');
```
And here is the empty filename always overwritten with `blob`.

## How to fix
In the plugin `www\helpers.js:456`:
```js
result.fileNames.push(entry.value[1].name !== undefined ? entry.value[1].name : 'blob');
```
Now the filename is only set to `blob` if it is not defined at all.

## Tests
I also added two test to cover all scenarios and fixed the FileMock for that.