### PR TITLE
Resolve #344 restore and fix redirect specs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ npm-debug.log
 /temp
 /android-sdk-macosx.zip
 /android-sdk-macosx/**
+.idea/
+*.iml

--- a/README.md
+++ b/README.md
@@ -477,6 +477,7 @@ This plugin uses amazing cloud services to maintain quality. CI Builds and E2E t
 * [BrowserStack](https://www.browserstack.com/)
 * [Sauce Labs](https://saucelabs.com/)
 * [httpbin.org](https://httpbin.org/)
+* [go-httpbin](https://httpbingo.org/)
 
 ## Contribute & Develop
 

--- a/test/e2e-specs.js
+++ b/test/e2e-specs.js
@@ -297,25 +297,25 @@ const tests = [
       JSON.parse(result.data.data).form.should.eql({ test: 'testString' });
     }
   },
-  // {
-  //   description: 'should resolve correct URL after redirect (GET) #33',
-  //   expected: 'resolved: {"status": 200, url: "http://httpbin.org/anything", ...',
-  //   func: function (resolve, reject) { cordova.plugin.http.get('http://httpbin.org/redirect-to?url=http://httpbin.org/anything', {}, {}, resolve, reject); },
-  //   validationFunc: function (driver, result) {
-  //     result.type.should.be.equal('resolved');
-  //     result.data.url.should.be.equal('http://httpbin.org/anything');
-  //   }
-  // },
-  // {
-  //   description: 'should not follow 302 redirect when following redirects is disabled',
-  //   expected: 'rejected: {"status": 302, ...',
-  //   before: function (resolve, reject) { cordova.plugin.http.disableRedirect(true, resolve, reject) },
-  //   func: function (resolve, reject) { cordova.plugin.http.get('http://httpbin.org/redirect-to?url=http://httpbin.org/anything', {}, {}, resolve, reject); },
-  //   validationFunc: function (driver, result) {
-  //     result.type.should.be.equal('rejected');
-  //     result.data.status.should.be.equal(302);
-  //   }
-  // },
+  {
+    description: 'should resolve correct URL after redirect (GET) #33',
+    expected: 'resolved: {"status": 200, url: "http://httpbin.org/anything", ...',
+    func: function (resolve, reject) { cordova.plugin.http.get('http://httpbingo.org/redirect-to?url=http://httpbin.org/anything', {}, {}, resolve, reject); },
+    validationFunc: function (driver, result) {
+      result.type.should.be.equal('resolved');
+      result.data.url.should.be.equal('http://httpbin.org/anything');
+    }
+  },
+  {
+    description: 'should not follow 302 redirect when following redirects is disabled',
+    expected: 'rejected: {"status": 302, ...',
+    before: function (resolve, reject) { cordova.plugin.http.disableRedirect(true, resolve, reject) },
+    func: function (resolve, reject) { cordova.plugin.http.get('http://httpbingo.org/redirect-to?url=http://httpbin.org/anything', {}, {}, resolve, reject); },
+    validationFunc: function (driver, result) {
+      result.type.should.be.equal('rejected');
+      result.data.status.should.be.equal(302);
+    }
+  },
   {
     description: 'should download a file from given URL to given path in local filesystem',
     expected: 'resolved: {"content": "<?xml version=\'1.0\' encoding=\'us-ascii\'?>\\n\\n<!--  A SAMPLE set of slides  -->" ...',

--- a/test/e2e-specs.js
+++ b/test/e2e-specs.js
@@ -309,7 +309,7 @@ const tests = [
   {
     description: 'should not follow 302 redirect when following redirects is disabled',
     expected: 'rejected: {"status": 302, ...',
-    before: function (resolve, reject) { cordova.plugin.http.disableRedirect(true, resolve, reject) },
+    before: function (resolve, reject) { cordova.plugin.http.setFollowRedirect(false); resolve(); },
     func: function (resolve, reject) { cordova.plugin.http.get('http://httpbingo.org/redirect-to?url=http://httpbin.org/anything', {}, {}, resolve, reject); },
     validationFunc: function (driver, result) {
       result.type.should.be.equal('rejected');


### PR DESCRIPTION
Replace only the **/redirect-to** endpoints to use http://httpbingo.org instead of _broken_ http://httpbin.org in this case.

Fix #344

---
~~Still a draft as I haven't been able to execute the e2e tests locally
(got the _build-test-app_ to work fine, but not the _test-app_ - errors with _wd_ when running mocha tests).~~

\+ maybe requires to update other resources for httpbingo.org:
- _update-e2e-server-cert.js_ for its cert?
- _network_security_config.xml_ to add domain?
- _index.html_ to update CSP content?

&rArr; not needed for now! To keep in mind if switching to httpbingo more.