### PR TITLE
Fix: Memory leak on iOS

### DIFF
--- a/src/ios/CordovaHttpPlugin.m
+++ b/src/ios/CordovaHttpPlugin.m
@@ -228,6 +228,7 @@
             CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:dictionary];
             [weakSelf.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
             [[SDNetworkActivityIndicator sharedActivityIndicator] stopActivity];
+            [manager invalidateSessionCancelingTasks:YES];
         };
 
         void (^onFailure)(NSURLSessionTask *, NSError *) = ^(NSURLSessionTask *task, NSError *error) {
@@ -239,6 +240,7 @@
             CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsDictionary:dictionary];
             [weakSelf.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
             [[SDNetworkActivityIndicator sharedActivityIndicator] stopActivity];
+            [manager invalidateSessionCancelingTasks:YES];
         };
 
         NSURLSessionDataTask *task = [manager downloadTaskWithHTTPMethod:method URLString:url parameters:nil progress:nil success:onSuccess failure:onFailure];
@@ -316,6 +318,7 @@
             CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:dictionary];
             [weakSelf.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
             [[SDNetworkActivityIndicator sharedActivityIndicator] stopActivity];
+            [manager invalidateSessionCancelingTasks:YES];
         };
 
         void (^onFailure)(NSURLSessionTask *, NSError *) = ^(NSURLSessionTask *task, NSError *error) {
@@ -327,6 +330,7 @@
             CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsDictionary:dictionary];
             [weakSelf.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
             [[SDNetworkActivityIndicator sharedActivityIndicator] stopActivity];
+            [manager invalidateSessionCancelingTasks:YES];
         };
 
         NSURLSessionDataTask *task;


### PR DESCRIPTION
**Plugin version**: 3.1.0
**Platform**: iOS

### Overview

- Requests are leaking instances of the AFHTTPSessionManager
- It appears many network resources associated with the request are held in memory as a result
- Over time this causes iOS to terminate the app
- Inspiration for the fix: https://stackoverflow.com/a/41345142

### Use case

I caught this on my app which is intended to run straight for extended periods of time (multiple days). I received reports that in iOS, the app was being force-closed within the first 12-16 hours. After investigation, it turned out to be related to certain use-cases which make frequent requests to local network resources (1+ per second). Profiling of the app revealed memory usage to be the issue, over time it would grow from ~60MB to > 1GB.

After applying the fix, the app stays within 66-67MB of memory during a multi-day run. 

### Profiling

Below is a screen of a 90 second run of my app with and without the fix, all other conditions remain equal:

#### Without the fix

![Original profile](https://i.imgur.com/jcX6cfn.png)

#### With the fix

![Fixed profile](https://i.imgur.com/7KZSYIJ.png)