### PR TITLE
Send requests on multiple server if it fails

### DIFF
--- a/www/public-interface.js
+++ b/www/public-interface.js
@@ -134,6 +134,20 @@ module.exports = function init(exec, cookieHandler, urlUtil, helpers, globalConf
   }
 
   function sendRequest(url, options, success, failure) {
+    if (Array.isArray(url)) {
+      if (url.length === 1) {
+        return sendRequest(url[0], options, success, failure);
+      }
+
+      return sendRequest(url[0], options, success, () => {
+        if (url.length > 2) {
+          sendRequest(url.slice(1), options, success, failure);
+        } else {
+          sendRequest(url[1], options, success, failure);
+        }
+      });
+    }
+
     helpers.handleMissingCallbacks(success, failure);
 
     options = helpers.handleMissingOptions(options, globalConfigs);


### PR DESCRIPTION
This modification allows to send a request to an array of servers, this simplify the problem of contacting multiple servers when the connection fails for any reason. If every request fails you get the answer from the last server contacted.

Example:
Multiple replica server [host1.abc.com, host2.abc.com, host3.abc.com]
If the request on host1.abc.com of a resource fails then it will try contacting host2.abc.com, then host3.abc.com
