### PR TITLE
Added support for intermediate certificates on iOS

### DIFF
--- a/src/ios/CordovaHttpPlugin.m
+++ b/src/ios/CordovaHttpPlugin.m
@@ -404,8 +404,18 @@
         } else {
             CFDictionaryRef identityDict = CFArrayGetValueAtIndex(items, 0);
             SecIdentityRef identity = (SecIdentityRef)CFDictionaryGetValue(identityDict, kSecImportItemIdentity);
+            SecTrustRef trust = (SecTrustRef)CFDictionaryGetValue(identityDict, kSecImportItemTrust);
 
-            self->x509Credential = [NSURLCredential credentialWithIdentity:identity certificates: nil persistence:NSURLCredentialPersistenceForSession];
+            int count = (int)SecTrustGetCertificateCount(trust);
+            NSMutableArray* trustCertificates = nil;
+            if (count > 1) {
+                trustCertificates = [NSMutableArray arrayWithCapacity:SecTrustGetCertificateCount(trust)];
+                for (int i=1;i<count; ++i) {
+                    [trustCertificates addObject:(id)SecTrustGetCertificateAtIndex(trust, i)];
+                }
+            }
+
+            self->x509Credential = [NSURLCredential credentialWithIdentity:identity certificates: trustCertificates persistence:NSURLCredentialPersistenceForSession];
             CFRelease(items);
 
             pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];


### PR DESCRIPTION
When using client certificates sometimes we need to specify intermediate CA certificates. Command line tools use parameters for it: `-CAfile` for `openssl s_client` or `--cacert` for `curl`. For this plugin Android platform takes intermediate certificates from PKCS12 structure well. For iOS it didn't work. This PR propose fix for this.