### PR TITLE
feat: ability to use custom storage for cookies

### DIFF
--- a/www/cookie-handler.js
+++ b/www/cookie-handler.js
@@ -9,7 +9,8 @@ module.exports = function init(storage, ToughCookie, WebStorageCookieStore) {
     setCookie: setCookie,
     getCookieString: getCookieString,
     clearCookies: clearCookies,
-    removeCookies: removeCookies
+    removeCookies: removeCookies,
+    setStorageImpl: setStorageImpl
   };
 
   function splitCookieString(cookieStr) {
@@ -53,7 +54,7 @@ module.exports = function init(storage, ToughCookie, WebStorageCookieStore) {
   }
 
   function clearCookies() {
-    window.localStorage.removeItem(storeKey);
+    storage.removeItem(storeKey);
   }
 
   function removeCookies(url, cb) {
@@ -66,5 +67,10 @@ module.exports = function init(storage, ToughCookie, WebStorageCookieStore) {
 
       cookieJar.store.removeCookies(domain, null, cb);
     });
+  }
+
+  function setStorageImpl(_storage) {
+    store.setStorageImpl(_storage)
+    storage = _storage;
   }
 };

--- a/www/local-storage-store.js
+++ b/www/local-storage-store.js
@@ -40,6 +40,10 @@ module.exports = function init(ToughCookie, _) {
 
   WebStorageCookieStore.prototype = Object.create(ToughCookie.Store);
 
+  WebStorageCookieStore.prototype.setStorageImpl = function (storage) {
+    this._storage = storage;
+  };
+
   WebStorageCookieStore.prototype.findCookie = function (domain, path, key, callback) {
     var store = this._readStore();
     var cookie = _.get(store, [domain, path, key], null);

--- a/www/public-interface.js
+++ b/www/public-interface.js
@@ -6,6 +6,7 @@ module.exports = function init(exec, cookieHandler, urlUtil, helpers, globalConf
     setHeader: setHeader,
     getDataSerializer: getDataSerializer,
     setDataSerializer: setDataSerializer,
+    setCookieStorageImpl: setCookieStorageImpl,
     setCookie: setCookie,
     clearCookies: clearCookies,
     removeCookies: removeCookies,
@@ -79,6 +80,18 @@ module.exports = function init(exec, cookieHandler, urlUtil, helpers, globalConf
 
   function setDataSerializer(serializer) {
     globalConfigs.serializer = helpers.checkSerializer(serializer);
+  }
+
+  /**
+   * Provides a custom cookie storage, to override the default localStorage
+   * @param {Object} storage 
+   * @param {(name: string, value: string) => void} storage.setItem 
+   * @param {(name: string) => string} storage.getItem 
+   * @param {(name: string) => void} storage.removeItem 
+   */
+  function setCookieStorageImpl(storage)
+  {
+    cookieHandler.setStorageImpl(storage);
   }
 
   function setCookie(url, cookie, options) {


### PR DESCRIPTION
**Motivation**
Cookies are stored in the **webview localStorage**.
According to #194, this may be an **issue** for some users who might want to **store cookies in native storage**, possibly **secured**.

This PR aims to **add a new interface** to `cordova.plugin.http` to be able **provide a custom (and synchronous) storage implementation**:
```javascript
/**
 * Provides a custom cookie storage, to override the default localStorage
 * @param {Object} storageImpl 
 * @param {(name: string, value: string) => void} storageImpl.setItem 
 * @param {(name: string) => string} storageImpl.getItem 
 * @param {(name: string) => void} storageImpl.removeItem 
 */
function setCookieStorageImpl(storageImpl)
```

Some trivial usage could be:
```javascript
cordova.plugin.http.setCookieStorageImpl({
  setItem: (name, value) =>
  {
    console.log(`setItem cookie ${name}`);
    localStorage.setItem(`myprefix_${name}`, value);
  },
  getItem: (name) =>
  {
    console.log(`getItem cookie ${name}`);
    return localStorage.getItem(`myprefix_${name}`);
  },
  removeItem: (name) =>
  {
    console.log(`removeItem cookie ${name}`);
    localStorage.removeItem(`myprefix_${name}`);
  }
})
```