### PR TITLE
fix: align sendRequest parameters for browser platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ This defaults to `urlencoded`. You can also override the default content type he
 Set how long to wait for a request to respond, in seconds.
 For Android, this will set both [connectTimeout](https://developer.android.com/reference/java/net/URLConnection#getConnectTimeout()) and [readTimeout](https://developer.android.com/reference/java/net/URLConnection#setReadTimeout(int))
 For iOS, this will set [timeout interval](https://developer.apple.com/documentation/foundation/nsmutableurlrequest/1414063-timeoutinterval)
+For browser platform, this will set [timeout](https://developer.mozilla.org/fr/docs/Web/API/XMLHttpRequest/timeout)
 ```js
 cordova.plugin.http.setRequestTimeout(5.0);
 ```

--- a/src/browser/cordova-http-plugin.js
+++ b/src/browser/cordova-http-plugin.js
@@ -159,15 +159,17 @@ function sendRequest(method, withData, opts, success, failure) {
     serializer = opts[2];
     headers = opts[3];
     timeout = opts[4];
-    followRedirect = opts[5];
-    responseType = opts[6];
-    reqId = opts[7];
+    // ignore opts[5] (read timeout)
+    followRedirect = opts[6];
+    responseType = opts[7];
+    reqId = opts[8];
   } else {
     headers = opts[1];
     timeout = opts[2];
-    followRedirect = opts[3];
-    responseType = opts[4];
-    reqId = opts[5];
+    // ignore opts[3] (read timeout)
+    followRedirect = opts[4];
+    responseType = opts[5];
+    reqId = opts[6];
   }
 
   var onSuccess = injectRequestIdHandler(reqId, success);


### PR DESCRIPTION
This PR fixes a bug on browser platform where followRedirect, responseType and reqId are not retrieved correctly. So if you expect for example a "blob" responseType, the value won't be sent to the xhr layer.

I think it is probably broken since introduction of connect and read timeout (commit 6f68aab73608d9d26543e46b5cf738d18e6929ed), where the parameters following connectTimeout are shifted by one.