### PR TITLE
[Browser] Fixing error propagation in setHeaders

### DIFF
--- a/src/browser/cordova-http-plugin.js
+++ b/src/browser/cordova-http-plugin.js
@@ -241,7 +241,7 @@ function sendRequest(method, withData, opts, success, failure) {
     setHeaders(xhr, headers);
   } catch(error) {
     return onFail({
-      status: -8,
+      status: -1,
       error: error,
       url: url,
       headers: headers

--- a/src/browser/cordova-http-plugin.js
+++ b/src/browser/cordova-http-plugin.js
@@ -237,7 +237,16 @@ function sendRequest(method, withData, opts, success, failure) {
   // we can't set connect timeout and read timeout separately on browser platform
   xhr.timeout = readTimeout * 1000;
 
-  setHeaders(xhr, headers);
+  try {
+    setHeaders(xhr, headers);
+  } catch(error) {
+    return onFail({
+      status: -8,
+      error: error,
+      url: url,
+      headers: headers
+    });
+  }
 
   xhr.onerror = function () {
     return onFail(createXhrFailureObject(xhr));


### PR DESCRIPTION
If the headers contain certain special characters (€, “, ≠, ∑, †, Ω etc..), calling the `setHeaders` method will throw an "_Value is not a valid ByteString_" error which unfortunately is neither propagated to the caller of the http-plugin, nor is the xhr request cancelled in this case.

By wrapping the `setHeader`-call into a try/catch, and fail the xhr request in case of an error, we'd make sure the caller of the http-plugin will receive a proper error and the xhr request gets canceled.