### PR TITLE
feat: response object on file download

### DIFF
--- a/README.md
+++ b/README.md
@@ -414,21 +414,32 @@ cordova.plugin.http.uploadFile("https://google.com/", {
 ```
 
 ### downloadFile<a name="downloadFile"></a>
-Downloads a file and saves it to the device.  Takes a URL, parameters, headers, and a filePath.  See [post](#post) documentation for details on what is returned on failure.  On success this function returns a cordova [FileEntry object](http://cordova.apache.org/docs/en/3.3.0/cordova_file_file.md.html#FileEntry).
+Downloads a file and saves it to the device.  Takes a URL, parameters, headers, and a filePath.  See [post](#post) documentation for details on what is returned on failure.  On success this function returns a cordova [FileEntry object](http://cordova.apache.org/docs/en/3.3.0/cordova_file_file.md.html#FileEntry) as first and the response object as second parameter.
 
 ```js
-cordova.plugin.http.downloadFile("https://google.com/", {
-  id: '12',
-  message: 'test'
-}, { Authorization: 'OAuth2: token' }, 'file:///somepicture.jpg', function(entry) {
-  // prints the filename
-  console.log(entry.name);
+cordova.plugin.http.downloadFile(
+  "https://google.com/", 
+  { id: '12', message: 'test' },
+  { Authorization: 'OAuth2: token' },
+  'file:///somepicture.jpg',
+  // success callback
+  function(entry, response) {
+    // prints the filename
+    console.log(entry.name);
 
-  // prints the filePath
-  console.log(entry.fullPath);
-}, function(response) {
-  console.error(response.error);
-});
+    // prints the filePath
+    console.log(entry.fullPath);
+
+    // prints all header key/value pairs
+    Object.keys(response.headers).forEach(function (key) {
+      console.log(key, response.headers[key]);
+    });
+  }, 
+  // error callback
+  function(response) {
+    console.error(response.error);
+  }
+);
 ```
 
 ### abort<a name="abort"></a>
@@ -445,12 +456,15 @@ If the request is still in progress, the request's `failure` callback will be in
 var requestId = cordova.plugin.http.downloadFile("https://google.com/", {
   id: '12',
   message: 'test'
-}, { Authorization: 'OAuth2: token' }, 'file:///somepicture.jpg', function(entry) {
+}, { Authorization: 'OAuth2: token' }, 'file:///somepicture.jpg', function(entry, response) {
   // prints the filename
   console.log(entry.name);
 
   // prints the filePath
   console.log(entry.fullPath);
+
+  // prints the status code
+  console.log(response.status);
 }, function(response) {
   // if request was actually aborted, failure callback with status -8 will be invoked
   if(response.status === -8){

--- a/www/helpers.js
+++ b/www/helpers.js
@@ -344,7 +344,7 @@ module.exports = function init(global, jsUtil, cookieHandler, messages, base64, 
   function injectFileEntryHandler(cb) {
     return function (response) {
       var fileEntry = createFileEntry(response.file);
-      // optional: delete response.file;
+      response.file = fileEntry;
       response.data = fileEntry;
       cb(fileEntry, response);
     }

--- a/www/helpers.js
+++ b/www/helpers.js
@@ -343,7 +343,10 @@ module.exports = function init(global, jsUtil, cookieHandler, messages, base64, 
 
   function injectFileEntryHandler(cb) {
     return function (response) {
-      cb(createFileEntry(response.file));
+      var fileEntry = createFileEntry(response.file);
+      // optional: delete response.file;
+      response.data = fileEntry;
+      cb(fileEntry, response);
     }
   }
 


### PR DESCRIPTION
As a user i may need access header or other meta information sent by the server. So i added the response object as second parameter to the success callback when triggered by `downloadFile(...)` or `sendRequest(..., { method: 'download', ... }, ...)` to make sure the feature maintains backward compatibility.

The response object will look like this:
```jsonc
{
    file: { ... }, // raw file object
    data: FileEntry, // exactly the same as first parameter
    headers: { ... }, // Header collection in form of key->value
    status: 200, // Status Code
    url: 'https://basictest.url'
}
```

You are now able to access the header information like this:
```javascript
cordova.plugin.http.downloadFile(
    "https://www.google.de",
    {}, 
    {}, 
    cordova.file.dataDirectory + 'test.html', 
    function(entry, response) { 
        const cType = response.headers['content-type'];
        const aProto = response.headers['x-android-selected-protocol'];
        // ...
    },
    console.error
);
```