### PR TITLE
Resolves #441 disable url cache

### DIFF
--- a/src/ios/SM_AFNetworking/SM_AFURLSessionManager.m
+++ b/src/ios/SM_AFNetworking/SM_AFURLSessionManager.m
@@ -511,6 +511,7 @@ static NSString * const AFNSURLSessionTaskDidSuspendNotification = @"com.alamofi
 
     if (!configuration) {
         configuration = [NSURLSessionConfiguration defaultSessionConfiguration];
+        configuration.URLCache = nil;
     }
 
     self.sessionConfiguration = configuration;


### PR DESCRIPTION
Without setting URLCache to nil (see apple [docs](https://developer.apple.com/documentation/foundation/nsurlsessionconfiguration/1410148-urlcache)) there is a potential for sensitive data to be stored in cache.db which can be accessed by jailbreaking the device. This problem is often picked up  during penetration testing audits on an application.