### PR TITLE
Update READ.md setCookie with removal message

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ cordova.plugin.http.getCookieString(url);
 ```
 
 ### setCookie
-Add a custom cookie. Takes a URL, a cookie string and an options object. See [ToughCookie documentation](https://github.com/salesforce/tough-cookie#setcookiecookieorstring-currenturl-options-cberrcookie) for allowed options.
+Add a custom cookie. Takes a URL, a cookie string and an options object. See [ToughCookie documentation](https://github.com/salesforce/tough-cookie#setcookiecookieorstring-currenturl-options-cberrcookie) for allowed options. Cookie will persist until removed with [removeCookies](#removecookies) or [clearCookies](#clearcookies).
 
 ```js
 cordova.plugin.http.setCookie(url, cookie, options);


### PR DESCRIPTION
https://github.com/silkimen/cordova-plugin-advanced-http/issues/472

Update the README for setCookie to reflect that either clearCookies or removeCookies will have to be manually called in order to remove the cookie. As explained in the above issue, this removes any potential confusion that the cookies are stored per session.