### PR TITLE
(feat) use non deprecated SecTrustEvaluateWithError, report cert errors

### DIFF
--- a/src/ios/SM_AFNetworking/SM_AFSecurityPolicy.m
+++ b/src/ios/SM_AFNetworking/SM_AFSecurityPolicy.m
@@ -91,11 +91,15 @@ _out:
 
 static BOOL AFServerTrustIsValid(SecTrustRef serverTrust) {
     BOOL isValid = NO;
-    SecTrustResultType result;
-    __Require_noErr_Quiet(SecTrustEvaluate(serverTrust, &result), _out);
+    CFErrorRef error = nil;
+    isValid = SecTrustEvaluateWithError(serverTrust, &error);
 
-    isValid = (result == kSecTrustResultUnspecified || result == kSecTrustResultProceed);
-
+#ifdef DEBUG
+    if (!isValid) {
+        NSError *nerror = (__bridge NSError *)error;
+        NSLog(@"%@",nerror);
+    }
+#endif
 _out:
     return isValid;
 }


### PR DESCRIPTION
This replaces the deprecated SecTrustEvaluate with SecTrustEvaluateWithError and will log certificate errors to aid during debugging.

An example reported certificate error is:
`Error Domain=NSOSStatusErrorDomain Code=-67843 ""GTS Root R1" certificate is not trusted" UserInfo={NSLocalizedDescription="GTS Root R1" certificate is not trusted`