### PR TITLE
feat: upload file without formdata

### DIFF
--- a/src/android/com/silkimen/cordovahttp/CordovaHttpPlugin.java
+++ b/src/android/com/silkimen/cordovahttp/CordovaHttpPlugin.java
@@ -163,12 +163,17 @@ public class CordovaHttpPlugin extends CordovaPlugin implements Observer {
     int readTimeout = args.getInt(5) * 1000;
     boolean followRedirect = args.getBoolean(6);
     String responseType = args.getString(7);
-    Integer reqId = args.getInt(8);
+    JSONObject transmitOptions = args.getJSONObject(8);
+    Integer reqId = args.getInt(9);
+
+    // new file transmission options
+    String transmitFileType = transmitOptions.getString("transmitFileAs");
+    boolean submitRaw = transmitFileType.equalsIgnoreCase("BINARY");
 
     CordovaObservableCallbackContext observableCallbackContext = new CordovaObservableCallbackContext(callbackContext, reqId);
 
     CordovaHttpUpload upload = new CordovaHttpUpload(url, headers, filePaths, uploadNames, connectTimeout, readTimeout, followRedirect,
-        responseType, this.tlsConfiguration, this.cordova.getActivity().getApplicationContext(), observableCallbackContext);
+        responseType, this.tlsConfiguration, submitRaw, this.cordova.getActivity().getApplicationContext(), observableCallbackContext);
 
     startRequest(reqId, observableCallbackContext, upload);
 

--- a/www/public-interface.js
+++ b/www/public-interface.js
@@ -180,7 +180,13 @@ module.exports = function init(exec, cookieHandler, urlUtil, helpers, globalConf
         break;
       case 'upload':
         var fileOptions = helpers.checkUploadFileOptions(options.filePath, options.name);
-        exec(onSuccess, onFail, 'CordovaHttpPlugin', 'uploadFiles', [url, headers, fileOptions.filePaths, fileOptions.names, options.connectTimeout, options.readTimeout, options.followRedirect, options.responseType, reqId]);
+        
+        // support uploading files as octet-stream / encoded string instead of form-data
+        var transmitOptions = {};
+        transmitOptions.transmitFileAs = options.transmitFileAs || 'FORMDATA';
+        // transmitOptions.transmitMethod = options.transmitMethod || 'POST';
+        
+        exec(onSuccess, onFail, 'CordovaHttpPlugin', 'uploadFiles', [url, headers, fileOptions.filePaths, fileOptions.names, options.connectTimeout, options.readTimeout, options.followRedirect, options.responseType, transmitOptions, reqId]);
         break;
       case 'download':
         var filePath = helpers.checkDownloadFilePath(options.filePath);


### PR DESCRIPTION
## Motivation

We want to support native file uploads without the use of form-data. Therefore it was necessary to supply more information to the "uploadFiles" command and create a new way to upload those raw files.

## ToDo
- [x] Android
- [x] iOS
- [ ] Tests
- [ ] Documentation

## Details

There is a new option 'transmitFileAs' which currently only supports `"BINARY"`, `NULL`, `undefined` or `any string except "binary"`. The default behavior is "FORMDATA". There is no need to change existing code.

If you want to use this new feature, you can use `http.sendRequest({ method: 'upload', fileName: '<yourfile>', transmitFileAs: 'BINARY', url: '<your url>' })`.
