### PR TITLE
Catch unanticipated EOFException due to empty stream when redirecting.

### DIFF
--- a/src/android/com/silkimen/http/HttpRequest.java
+++ b/src/android/com/silkimen/http/HttpRequest.java
@@ -37,6 +37,7 @@ import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.Closeable;
+import java.io.EOFException;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
@@ -2489,10 +2490,14 @@ public class HttpRequest {
       public HttpRequest run() throws IOException {
         final byte[] buffer = new byte[bufferSize];
         int read;
-        while ((read = input.read(buffer)) != -1) {
-          output.write(buffer, 0, read);
-          totalWritten += read;
-          progress.onUpload(totalWritten, totalSize);
+        try{
+          while ((read = input.read(buffer)) != -1) {
+            output.write(buffer, 0, read);
+            totalWritten += read;
+            progress.onUpload(totalWritten, totalSize);
+          }
+        }catch(EOFException e){
+          e.printStackTrace();
         }
         return HttpRequest.this;
       }


### PR DESCRIPTION
When one wants to disable followRedirect, sometimes the InputStream will throw an EOFException due to there being no content in the response body. It is undesired for this to result in an error returned to Cordova, as the end user would just want to be able to read the Location header anyway (and follow it if necessary).