### PR TITLE
Update CordovaHttpBase.java - Bugfix 482, omit Accept-Charset header

### DIFF
--- a/src/android/com/silkimen/cordovahttp/CordovaHttpBase.java
+++ b/src/android/com/silkimen/cordovahttp/CordovaHttpBase.java
@@ -133,7 +133,7 @@ abstract class CordovaHttpBase implements Runnable {
     request.followRedirects(this.followRedirects);
     request.connectTimeout(this.connectTimeout);
     request.readTimeout(this.readTimeout);
-    request.acceptCharset("UTF-8");
+    //request.acceptCharset("UTF-8");
     request.uncompress(true);
 
     if (this.tlsConfiguration.getHostnameVerifier() != null) {

--- a/src/android/com/silkimen/cordovahttp/CordovaHttpBase.java
+++ b/src/android/com/silkimen/cordovahttp/CordovaHttpBase.java
@@ -133,7 +133,6 @@ abstract class CordovaHttpBase implements Runnable {
     request.followRedirects(this.followRedirects);
     request.connectTimeout(this.connectTimeout);
     request.readTimeout(this.readTimeout);
-    //request.acceptCharset("UTF-8");
     request.uncompress(true);
 
     if (this.tlsConfiguration.getHostnameVerifier() != null) {


### PR DESCRIPTION
Having the same problems with 403 returned because Accept-Charset header is being set. 

Fix as per suggestion in issue 

https://github.com/silkimen/cordova-plugin-advanced-http/issues/482