### PR TITLE
[Android] Stop adding unnecessary new lines into base64 response string

### DIFF
--- a/src/android/com/silkimen/cordovahttp/CordovaHttpResponse.java
+++ b/src/android/com/silkimen/cordovahttp/CordovaHttpResponse.java
@@ -75,7 +75,7 @@ class CordovaHttpResponse {
     } else if (this.isFileOperation) {
       json.put("file", this.fileEntry);
     } else if (this.isRawResponse) {
-      json.put("data", Base64.encodeToString(this.rawData, Base64.DEFAULT));
+      json.put("data", Base64.encodeToString(this.rawData, Base64.NO_WRAP));
     } else {
       json.put("data", this.body);
     }


### PR DESCRIPTION
[base64.fromArrayBuffer](https://github.com/apache/cordova-js/blob/master/src/common/base64.js#L24) is perfectly capable of decoding one long line of base64 string. We just waste memory with those `\n` characters.