### PR TITLE
Fix build on cordova-ios 8: add missing UIKit import for SDNetworkActivityIndicator

### DIFF
--- a/src/ios/SDNetworkActivityIndicator/SDNetworkActivityIndicator.m
+++ b/src/ios/SDNetworkActivityIndicator/SDNetworkActivityIndicator.m
@@ -6,6 +6,7 @@
  * file that was distributed with this source code.
  */
 
+#import <UIKit/UIKit.h>
 #import "SDNetworkActivityIndicator.h"
 
 @interface SDNetworkActivityIndicator()


### PR DESCRIPTION
This PR fixes an iOS build failure that occurs after upgrading to cordova-ios 8.x.

### Background
When using this plugin with cordova-ios 8.x, Xcode build/archiving fails while compiling:
- src/ios/SDNetworkActivityIndicator/SDNetworkActivityIndicator.m

The error is caused by missing UIKit symbols (e.g. UIApplication, UIStatusBarStyle, etc.) because the file does not explicitly import UIKit.

### What changed
- Add #import <UIKit/UIKit.h> to SDNetworkActivityIndicator.m.