### PR TITLE
Fix build error in latest Xcode update

### DIFF
--- a/src/ios/SM_AFNetworking/SM_AFHTTPSessionManager.m
+++ b/src/ios/SM_AFNetworking/SM_AFHTTPSessionManager.m
@@ -29,7 +29,6 @@
 #import <Security/Security.h>
 
 #import <netinet/in.h>
-#import <netinet6/in6.h>
 #import <arpa/inet.h>
 #import <ifaddrs.h>
 #import <netdb.h>

--- a/src/ios/SM_AFNetworking/SM_AFNetworkReachabilityManager.m
+++ b/src/ios/SM_AFNetworking/SM_AFNetworkReachabilityManager.m
@@ -23,7 +23,6 @@
 #if !TARGET_OS_WATCH
 
 #import <netinet/in.h>
-#import <netinet6/in6.h>
 #import <arpa/inet.h>
 #import <ifaddrs.h>
 #import <netdb.h>


### PR DESCRIPTION
This PR fixes build errors that started happening after latest Xcode updates.

# Background
`Use of private header from outside its module: 'netinet6/in6.h'` error occurs in two files. It is enough to simply remove the import line, because everything is already imported through `netinet/in.h` which imports the private header internally.

# What  changed
Two import lines removed