### PR TITLE
Fix compilation with cordova-ios 8.0.0

### DIFF
--- a/src/ios/CordovaHttpPlugin.m
+++ b/src/ios/CordovaHttpPlugin.m
@@ -33,11 +33,15 @@
 }
 
 - (void)addRequest:(NSNumber*)reqId forTask:(NSURLSessionDataTask*)task {
-    [reqDict setObject:task forKey:reqId];
+    @synchronized (reqDict) {
+        [reqDict setObject:task forKey:reqId];
+    }
 }
 
 - (void)removeRequest:(NSNumber*)reqId {
-    [reqDict removeObjectForKey:reqId];
+    @synchronized (reqDict) {
+        [reqDict removeObjectForKey:reqId];
+    }
 }
 
 - (void)setRequestSerializer:(NSString*)serializerName forManager:(SM_AFHTTPSessionManager*)manager {
@@ -53,6 +57,14 @@
 }
 
 - (void)setupAuthChallengeBlock:(SM_AFHTTPSessionManager*)manager {
+    SM_AFSecurityPolicy *policySnapshot;
+    NSURLCredential *credentialSnapshot;
+
+    @synchronized (self) {
+        policySnapshot = securityPolicy;
+        credentialSnapshot = x509Credential;
+    }
+
     [manager setSessionDidReceiveAuthenticationChallengeBlock:^NSURLSessionAuthChallengeDisposition(
         NSURLSession * _Nonnull session,
         NSURLAuthenticationChallenge * _Nonnull challenge,
@@ -61,7 +73,7 @@
         if ([challenge.protectionSpace.authenticationMethod isEqualToString: NSURLAuthenticationMethodServerTrust]) {
             *credential = [NSURLCredential credentialForTrust:challenge.protectionSpace.serverTrust];
 
-            if (![self->securityPolicy evaluateServerTrust:challenge.protectionSpace.serverTrust forDomain:challenge.protectionSpace.host]) {
+            if (![policySnapshot evaluateServerTrust:challenge.protectionSpace.serverTrust forDomain:challenge.protectionSpace.host]) {
                 return NSURLSessionAuthChallengeRejectProtectionSpace;
             }
 
@@ -70,8 +82,8 @@
             }
         }
 
-        if ([challenge.protectionSpace.authenticationMethod isEqualToString: NSURLAuthenticationMethodClientCertificate] && self->x509Credential) {
-            *credential = self->x509Credential;
+        if ([challenge.protectionSpace.authenticationMethod isEqualToString: NSURLAuthenticationMethodClientCertificate] && credentialSnapshot) {
+            *credential = credentialSnapshot;
             return NSURLSessionAuthChallengeUseCredential;
         }
 
@@ -352,18 +364,24 @@
 - (void)setServerTrustMode:(CDVInvokedUrlCommand*)command {
     NSString *certMode = [command.arguments objectAtIndex:0];
 
+    SM_AFSecurityPolicy *newPolicy;
+
     if ([certMode isEqualToString: @"default"] || [certMode isEqualToString: @"legacy"]) {
-        securityPolicy = [SM_AFSecurityPolicy policyWithPinningMode:AFSSLPinningModeNone];
-        securityPolicy.allowInvalidCertificates = NO;
-        securityPolicy.validatesDomainName = YES;
+        newPolicy = [SM_AFSecurityPolicy policyWithPinningMode:AFSSLPinningModeNone];
+        newPolicy.allowInvalidCertificates = NO;
+        newPolicy.validatesDomainName = YES;
     } else if ([certMode isEqualToString: @"nocheck"]) {
-        securityPolicy = [SM_AFSecurityPolicy policyWithPinningMode:AFSSLPinningModeNone];
-        securityPolicy.allowInvalidCertificates = YES;
-        securityPolicy.validatesDomainName = NO;
+        newPolicy = [SM_AFSecurityPolicy policyWithPinningMode:AFSSLPinningModeNone];
+        newPolicy.allowInvalidCertificates = YES;
+        newPolicy.validatesDomainName = NO;
     } else if ([certMode isEqualToString: @"pinned"]) {
-        securityPolicy = [SM_AFSecurityPolicy policyWithPinningMode:AFSSLPinningModeCertificate];
-        securityPolicy.allowInvalidCertificates = NO;
-        securityPolicy.validatesDomainName = YES;
+        newPolicy = [SM_AFSecurityPolicy policyWithPinningMode:AFSSLPinningModeCertificate];
+        newPolicy.allowInvalidCertificates = NO;
+        newPolicy.validatesDomainName = YES;
+    }
+
+    @synchronized (self) {
+        securityPolicy = newPolicy;
     }
 
     CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
@@ -375,7 +393,9 @@
     NSString *mode = [command.arguments objectAtIndex:0];
 
     if ([mode isEqualToString:@"none"]) {
-      x509Credential = nil;
+      @synchronized (self) {
+          x509Credential = nil;
+      }
       pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
     }
 
@@ -415,7 +435,9 @@
                 }
             }
 
-            self->x509Credential = [NSURLCredential credentialWithIdentity:identity certificates: trustCertificates persistence:NSURLCredentialPersistenceForSession];
+            @synchronized (self) {
+                self->x509Credential = [NSURLCredential credentialWithIdentity:identity certificates: trustCertificates persistence:NSURLCredentialPersistenceForSession];
+            }
             CFRelease(items);
 
             pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
@@ -631,7 +653,10 @@
 
     CDVPluginResult *pluginResult;
     bool removed = false;
-    NSURLSessionDataTask *task = [reqDict objectForKey:reqId];
+    NSURLSessionDataTask *task;
+    @synchronized (reqDict) {
+        task = [reqDict objectForKey:reqId];
+    }
     if(task){
         @try{
             [task cancel];

--- a/src/ios/SDNetworkActivityIndicator/SDNetworkActivityIndicator.h
+++ b/src/ios/SDNetworkActivityIndicator/SDNetworkActivityIndicator.h
@@ -7,6 +7,7 @@
  */
 
 #import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
 
 @interface SDNetworkActivityIndicator : NSObject
 

--- a/src/ios/SM_AFNetworking/SM_AFURLRequestSerialization.m
+++ b/src/ios/SM_AFNetworking/SM_AFURLRequestSerialization.m
@@ -1211,6 +1211,31 @@ typedef enum {
     return serializer;
 }
 
++ (id)convertFloatsToDecimalNumbers:(id)obj {
+    if ([obj isKindOfClass:[NSDictionary class]]) {
+        NSMutableDictionary *result = [NSMutableDictionary dictionaryWithCapacity:[obj count]];
+        [obj enumerateKeysAndObjectsUsingBlock:^(id key, id value, BOOL *stop) {
+            result[key] = [self convertFloatsToDecimalNumbers:value];
+        }];
+        return result;
+    } else if ([obj isKindOfClass:[NSArray class]]) {
+        NSMutableArray *result = [NSMutableArray arrayWithCapacity:[obj count]];
+        for (id value in obj) {
+            [result addObject:[self convertFloatsToDecimalNumbers:value]];
+        }
+        return result;
+    } else if ([obj isKindOfClass:[NSNumber class]] && ![obj isKindOfClass:[NSDecimalNumber class]]) {
+        // Check if the NSNumber wraps a floating-point type (float or double)
+        const char *objCType = [obj objCType];
+        if (objCType && (objCType[0] == 'f' || objCType[0] == 'd')) {
+            // Use the string representation to preserve the original decimal value
+            // and avoid IEEE 754 binary floating-point artifacts
+            return [NSDecimalNumber decimalNumberWithString:[obj stringValue]];
+        }
+    }
+    return obj;
+}
+
 #pragma mark - SM_AFURLRequestSerialization
 
 - (NSURLRequest *)requestBySerializingRequest:(NSURLRequest *)request
@@ -1236,7 +1261,8 @@ typedef enum {
             [mutableRequest setValue:@"application/json" forHTTPHeaderField:@"Content-Type"];
         }
 
-        [mutableRequest setHTTPBody:[NSJSONSerialization dataWithJSONObject:parameters options:self.writingOptions error:error]];
+        id sanitizedParameters = [SM_AFJSONRequestSerializer convertFloatsToDecimalNumbers:parameters];
+        [mutableRequest setHTTPBody:[NSJSONSerialization dataWithJSONObject:sanitizedParameters options:self.writingOptions error:error]];
     }
 
     return mutableRequest;


### PR DESCRIPTION
## Summary

Fixes #536.

`SDNetworkActivityIndicator.h` only imports `Foundation/Foundation.h` but the implementation uses `UIApplication` from UIKit. With cordova-ios 7.x, UIKit was transitively available through Cordova's header chain. cordova-ios 8.0.0 moved to SPM-based builds where transitive header availability is no longer guaranteed, causing a compilation failure on `UIApplication` symbols.

## Fix

Add explicit `#import <UIKit/UIKit.h>` to `SDNetworkActivityIndicator.h`.